### PR TITLE
Fixed an exeption that would occur when 'parse' was not included in the annotators

### DIFF
--- a/lib/getParsedTree.js
+++ b/lib/getParsedTree.js
@@ -53,7 +53,7 @@ var ParsedTree = (function() {
 })();
 
 var getParsedTree = function(treeString) {
-  return new ParsedTree(treeString).parsedTree;
+  return treeString !== void 0 ? new ParsedTree(treeString).parsedTree : {};
 };
 
 module.exports = getParsedTree;


### PR DESCRIPTION
Hi!

I encountered an exception saying

```
TypeError: Cannot read property 'slice' of undefined
    at ParsedTree.parseRecursive (stanford-corenlp/lib/getParsedTree.js:13:28)
    at new ParsedTree (stanford-corenlp/lib/getParsedTree.js:6:10)
    at getParsedTree (stanford-corenlp/lib/getParsedTree.js:56:10)
    at stanford-corenlp/lib/StanfordNLP.js:125:45
    at Parser.<anonymous> (xml2js/lib/xml2js.js:484:18)
    at emitOne (events.js:90:13)
    at Parser.emit (events.js:182:7)
    at Object.onclosetag (xml2js/lib/xml2js.js:445:26)
    at emit (sax/lib/sax.js:639:35)
    at emitNode (sax/lib/sax.js:644:5)
```

when I was running examples/sentiments.js with following configurations:

```
var config = {

    'nlpPath':path.join ( __dirname,'./../corenlp'), //the path of corenlp
    'version':'3.5.2', //what version of corenlp are you using
    'annotators': ['tokenize','ssplit','pos','lemma'], //optional!

};
```

It seems that when 'parse' annotator is not included, `ParsedTree` try to parse `undefined`, which causes an error.
This PR fixes this error by adding an condition statement to avoid creating an instance of `ParsedTree` with `undefined`.
